### PR TITLE
feature: implement GitHub Actions workflows

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -1,0 +1,20 @@
+name: Build .NET
+inputs:
+  configuration:
+    required: false
+    default: Debug
+  framework:
+    required: true
+runs:
+  using: composite
+  steps:
+  - name: Build (${{ inputs.configuration }}) ${{ inputs.framework }}
+    shell: bash
+    run: |-
+      configuration=${{ inputs.configuration }}
+      framework=${{ inputs.framework }}
+      for a in $(rg --files-with-matches  --type-add "csp:*.csproj" -tcsp "${framework}"); do
+        echo "Building $a with ${framework}/${configuration}"
+        echo dotnet build -f ${framework} -c ${configuration} $a
+        dotnet build -f ${framework} -c ${configuration} $a
+      done

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -11,10 +11,4 @@ runs:
   - name: Build (${{ inputs.configuration }}) ${{ inputs.framework }}
     shell: bash
     run: |-
-      configuration=${{ inputs.configuration }}
-      framework=${{ inputs.framework }}
-      for a in $(rg --files-with-matches  --type-add "csp:*.csproj" -tcsp "${framework}"); do
-        echo "Building $a with ${framework}/${configuration}"
-        echo dotnet build -f ${framework} -c ${configuration} $a
-        dotnet build -f ${framework} -c ${configuration} $a
-      done
+      dotnet build -f ${{ inputs.framework }} -c ${{ inputs.configuration }} Unity.Mathematics

--- a/.github/actions/fetch-source/action.yml
+++ b/.github/actions/fetch-source/action.yml
@@ -6,6 +6,7 @@ runs:
     with:
       repositoryUrl: https://github.com/Unity-Technologies/Unity.Mathematics.git
       repositoryPath: Unity.Mathematics-orig
+      repositoryBranch: master
   - name: Copy source files
     shell: bash
     run: |

--- a/.github/actions/nuget-pack/action.yml
+++ b/.github/actions/nuget-pack/action.yml
@@ -1,0 +1,22 @@
+name: nuget pack
+inputs:
+  configuration:
+    required: false
+    default: Release
+  framework:
+    required: true
+runs:
+  using: composite
+  steps:
+  - uses: ./.github/actions/build
+    with:
+      configuration: "${{ inputs.configuration }}"
+      framework: "${{ inputs.framework }}"
+  - name: Run nuget pack with ${{ inputs.framework }}
+    shell: bash
+    run: |-
+      framework=${{ inputs.framework }}
+      for a in $(rg --files-with-matches  --type-add "csp:*.csproj" -tcsp "${framework}"); do
+        dotnet pack -c ${{ inputs.configuration }} -p:TargetFramework=${framework} $a || echo "Error"
+      done
+      fdfind --no-ignore nupkg$

--- a/.github/actions/nuget-pack/action.yml
+++ b/.github/actions/nuget-pack/action.yml
@@ -15,8 +15,5 @@ runs:
   - name: Run nuget pack with ${{ inputs.framework }}
     shell: bash
     run: |-
-      framework=${{ inputs.framework }}
-      for a in $(rg --files-with-matches  --type-add "csp:*.csproj" -tcsp "${framework}"); do
-        dotnet pack -c ${{ inputs.configuration }} -p:TargetFramework=${framework} $a || echo "Error"
-      done
+      dotnet pack -c ${{ inputs.configuration }} -p:TargetFramework=${framework} Unity.Mathematics
       fdfind --no-ignore nupkg$

--- a/.github/actions/nuget-publish/action.yml
+++ b/.github/actions/nuget-publish/action.yml
@@ -1,0 +1,14 @@
+name: nuget publish
+inputs:
+  registry:
+    required: true
+  token:
+    required: true
+runs:
+  using: composite
+  steps:
+  - name: nuget push to ${{ inputs.registry }}
+    shell: bash
+    run: |-
+      fdfind --no-ignore nupkg$
+      fdfind --no-ignore nupkg$ -x dotnet nuget push {} --api-key ${{ inputs.token }}  --source "${{ inputs.registry }}"

--- a/.github/jobactions/build/action.yml
+++ b/.github/jobactions/build/action.yml
@@ -11,6 +11,7 @@ runs:
   - uses: kagekirin/gha-utils/.github/actions/install-prerequisites@main
   - uses: kagekirin/gha-utils/.github/actions/install-version-tools@main
   - name: Build ${{ inputs.framework }} ${{ inputs.configuration }}
-    shell: bash
-    run: |-
-      dotnet build -f ${{ inputs.framework }} -c ${{ inputs.configuration }} Unity.Mathematics
+    uses: ./.github/actions/build
+    with:
+      framework: ${{ inputs.framework }}
+      configuration: ${{ inputs.configuration }}

--- a/.github/jobactions/build/action.yml
+++ b/.github/jobactions/build/action.yml
@@ -10,7 +10,6 @@ runs:
   steps:
   - uses: kagekirin/gha-utils/.github/actions/install-prerequisites@main
   - uses: kagekirin/gha-utils/.github/actions/install-version-tools@main
-  - uses: ./.github/actions/fetch-source
   - name: Build ${{ inputs.framework }} ${{ inputs.configuration }}
     shell: bash
     run: |-

--- a/.github/jobactions/nuget-prepare-publish/action.yml
+++ b/.github/jobactions/nuget-prepare-publish/action.yml
@@ -1,0 +1,32 @@
+name: jobactions/nuget-prepare-publish
+runs:
+  using: composite
+  steps:
+  - uses: kagekirin/gha-utils/.github/actions/install-prerequisites@main
+  - uses: kagekirin/gha-dotnet/.github/actions/nuget-add-registry@main
+    with:
+      name: github-nuget
+      registry: https://nuget.pkg.github.com/kagekirin/unity.mathematics.nuget/index.json
+      username: kagekirin
+      token: ${{ github.token }}
+  - uses: ./.github/jobactions/build
+    with:
+      framework: netstandard2.1
+      configuration: Release
+  - uses: kagekirin/gha-dotnet/.github/actions/nuget-pack@main
+    with:
+      framework: netstandard2.1
+  - uses: ./.github/jobactions/build
+    with:
+      framework: net6.0
+      configuration: Release
+  - uses: kagekirin/gha-dotnet/.github/actions/nuget-pack@main
+    with:
+      framework: net6.0
+  - uses: ./.github/jobactions/build
+    with:
+      framework: net7.0
+      configuration: Release
+  - uses: kagekirin/gha-dotnet/.github/actions/nuget-pack@main
+    with:
+      framework: net7.0

--- a/.github/jobactions/nuget-prepare-publish/action.yml
+++ b/.github/jobactions/nuget-prepare-publish/action.yml
@@ -13,20 +13,20 @@ runs:
     with:
       framework: netstandard2.1
       configuration: Release
-  - uses: kagekirin/gha-dotnet/.github/actions/nuget-pack@main
+  - uses: ./.github/actions/nuget-pack
     with:
       framework: netstandard2.1
   - uses: ./.github/jobactions/build
     with:
       framework: net6.0
       configuration: Release
-  - uses: kagekirin/gha-dotnet/.github/actions/nuget-pack@main
+  - uses: ./.github/actions/nuget-pack
     with:
       framework: net6.0
   - uses: ./.github/jobactions/build
     with:
       framework: net7.0
       configuration: Release
-  - uses: kagekirin/gha-dotnet/.github/actions/nuget-pack@main
+  - uses: ./.github/actions/nuget-pack
     with:
       framework: net7.0

--- a/.github/jobactions/tag/action.yml
+++ b/.github/jobactions/tag/action.yml
@@ -1,0 +1,69 @@
+name: jobactions/tag
+inputs:
+  prerelease:
+    description: version '-prerelease.num' part
+    required: false
+    default: ''
+  buildmeta:
+    description: version '+buildmeta.text' part
+    required: false
+    default: ''
+outputs:
+  version:
+    description: updated tag/version
+    value: ${{ steps.update-tag.outputs.value }}
+runs:
+  using: composite
+  steps:
+  - uses: kagekirin/gha-utils/.github/actions/install-prerequisites@main
+  - uses: kagekirin/gha-utils/.github/actions/install-version-tools@main
+  - uses: ./.github/actions/fetch-source
+  - id: product-version
+    uses: kagekirin/node-package-version/.github/actions/get-version@main
+    with:
+      file: Unity.Mathematics-orig/src/package.json
+  - shell: bash
+    run: |-
+      echo "${{ steps.product-version.outputs.version }}"
+  - id: get-revcount
+    shell: bash
+    run: |-
+      revcount=$(git rev-list --tags --count)
+      echo "revcount=${revcount}"
+      echo "revcount=${revcount}" >> $GITHUB_OUTPUT
+  - shell: bash
+    run: |-
+      echo "revcount=${{ steps.get-revcount.outputs.revcount }}"
+  - id: generate-tag
+    shell: bash
+    run: |-
+      tag=${{ steps.product-version.outputs.version }}
+
+      if [[ -n ${{ inputs.prerelease }} ]]; then
+        tag=$tag-${{ inputs.prerelease }}.${{ steps.get-revcount.outputs.revcount }}
+      fi
+
+      if [[ -n ${{ inputs.buildmeta }} ]]; then
+        tag=$tag+${{ inputs.buildmeta }}
+      fi
+      echo "tag=${tag}" >> $GITHUB_OUTPUT
+  - id: update-tag
+    shell: bash
+    run: |-
+      git config --local user.name "CI Bot [on behalf of Chris Helmich]"
+      git config --local user.email kagekirin+gha@gmail.com
+      git --no-pager status
+      git --no-pager tag -l --sort=-v:refname | head -n 1
+
+      version=${{ steps.generate-tag.outputs.tag }}
+      echo "Version: ${version}"
+      npm version ${version} --no-git-tag-version
+      csproj-version set --version ${version} --xpath '//PropertyGroup/Version' Unity.Mathematics/Unity.Mathematics.csproj
+
+      git add package.json
+      git add Unity.Mathematics/Unity.Mathematics.csproj
+      git commit -m "chore: update version to ${version}"
+      git tag -f v${version}
+
+      git --no-pager tag -l --sort=-v:refname | head -n 1
+      echo "value=${version}" >> $GITHUB_OUTPUT

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -26,11 +26,23 @@ jobs:
     steps:
     - uses: actions/checkout@v3.5.0
     - uses: ./.github/actions/fetch-source
-    - uses: ./.github/jobactions/tag
+    - id: create-tag
+      uses: ./.github/jobactions/tag
       with:
         prerelease: nuget
-        buildmeta: 'xx'
+    - shell: bash
+      run: |-
+        git checkout -b ci/tag-${{ steps.create-tag.outputs.version }} main
     - uses: kagekirin/gha-utils/.github/actions/git-push-tag@main
       with:
         repositoryUrl: origin
-        branch: main
+        baseBranch: main
+        mergeBranch: ci/tag-${{ steps.create-tag.outputs.version }}
+
+  test-nuget:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+    - uses: actions/checkout@v3.5.0
+    - uses: ./.github/actions/fetch-source
+    - uses: ./.github/jobactions/nuget-prepare-publish

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -14,6 +14,7 @@ jobs:
         framework: [netstandard2.1, net6.0, net7.0]
     steps:
     - uses: actions/checkout@v3.5.0
+    - uses: ./.github/actions/fetch-source
     - uses: ./.github/jobactions/build
       with:
         configuration: ${{ matrix.configuration }}

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -19,3 +19,18 @@ jobs:
       with:
         configuration: ${{ matrix.configuration }}
         framework: ${{ matrix.framework }}
+
+  tag:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+    - uses: actions/checkout@v3.5.0
+    - uses: ./.github/actions/fetch-source
+    - uses: ./.github/jobactions/tag
+      with:
+        prerelease: nuget
+        buildmeta: 'xx'
+    - uses: kagekirin/gha-utils/.github/actions/git-push-tag@main
+      with:
+        repositoryUrl: origin
+        branch: main

--- a/.github/workflows/build-cron.yml
+++ b/.github/workflows/build-cron.yml
@@ -1,0 +1,46 @@
+name: Unity.Mathematics.NuGet/build-cron
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  build:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        configuration: [Debug, Release]
+        framework: [netstandard2.1, net6.0, net7.0]
+    steps:
+    - uses: actions/checkout@v3.5.0
+    - uses: ./.github/actions/fetch-source
+    - uses: ./.github/jobactions/build
+      with:
+        configuration: ${{ matrix.configuration }}
+        framework: ${{ matrix.framework }}
+
+  test-nuget:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+    - uses: actions/checkout@v3.5.0
+    - uses: ./.github/actions/fetch-source
+    - uses: ./.github/jobactions/nuget-prepare-publish
+
+  tag:
+    runs-on: ubuntu-latest
+    needs: tag
+    steps:
+    - uses: actions/checkout@v3.5.0
+    - uses: ./.github/actions/fetch-source
+    - id: create-tag
+      uses: ./.github/jobactions/tag
+    - shell: bash
+      run: |-
+        git checkout -b ci/tag-${{ steps.create-tag.outputs.version }} main
+    - uses: kagekirin/gha-utils/.github/actions/git-push-tag@main
+      with:
+        repositoryUrl: origin
+        baseBranch: main
+        mergeBranch: ci/tag-${{ steps.create-tag.outputs.version }}

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -19,3 +19,15 @@ jobs:
       with:
         configuration: ${{ matrix.configuration }}
         framework: ${{ matrix.framework }}
+
+  test-tag:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+    - uses: actions/checkout@v3.5.0
+    - uses: ./.github/actions/fetch-source
+    - id: create-tag
+      uses: ./.github/jobactions/tag
+      with:
+        prerelease: nuget
+        buildmeta: 'xx'

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -31,3 +31,11 @@ jobs:
       with:
         prerelease: nuget
         buildmeta: 'xx'
+
+  test-nuget:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+    - uses: actions/checkout@v3.5.0
+    - uses: ./.github/actions/fetch-source
+    - uses: ./.github/jobactions/nuget-prepare-publish

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -14,6 +14,7 @@ jobs:
         framework: [netstandard2.1, net6.0, net7.0]
     steps:
     - uses: actions/checkout@v3.5.0
+    - uses: ./.github/actions/fetch-source
     - uses: ./.github/jobactions/build
       with:
         configuration: ${{ matrix.configuration }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,33 @@
+name: Unity.Mathematics.NuGet/publish
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        configuration: [Debug, Release]
+        framework: [netstandard2.1, net6.0, net7.0]
+    steps:
+    - uses: actions/checkout@v3.5.0
+    - uses: ./.github/actions/fetch-source
+    - uses: ./.github/jobactions/build
+      with:
+        configuration: ${{ matrix.configuration }}
+        framework: ${{ matrix.framework }}
+
+  nuget:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+    - uses: actions/checkout@v3.5.0
+    - uses: ./.github/actions/fetch-source
+    - uses: ./.github/jobactions/nuget-prepare-publish
+    - uses: kagekirin/gha-dotnet/.github/actions/nuget-publish@main
+      with:
+        registry: github-nuget
+        token: ${{ github.token }}


### PR DESCRIPTION
- refactor ('build' job action): remove call to 'fetch-source' action
- feature: add 'tag' job action
- feature: add job 'test-tag' to 'build-pr' workflow
- feature: add job 'tag' to 'build-ci' workflow
- feature: add 'nuget-prepare-publish' job action
- feature: add job 'test-nuget' to 'build-pr' workflow
- feature: add job 'test-nuget' to 'build-ci' workflow
- feature: add 'build-cron' workflow
- feature: add 'publish' workflow
- refactor ('fetch-source' action): pass input 'repositoryBranch' to 'git-checkout-repo' action
- feature: add 'build' action
- feature: add 'nuget-pack' action
- feature: add 'nuget-publish' action
- refactor ('build' job action): replace 'dotnet build' shell with call to 'build' action
- refactor ('nuget-prepare-publish' job action): replace calls to 'gha-dotnet/nuget-pack' with call to local 'nuget-pack'
- refactor ('build' action): replace for loop with direct call to 'dotnet build Unity.Mathematics'
- refactor ('nuget-pack' action): replace for loop with direct call to 'dotnet pack Unity.Mathematics'
