### PR TITLE
refactor: fix bash script for tag composition

### DIFF
--- a/.github/jobactions/tag/action.yml
+++ b/.github/jobactions/tag/action.yml
@@ -37,16 +37,18 @@ runs:
   - id: generate-tag
     shell: bash
     run: |-
-      tag=${{ steps.product-version.outputs.version }}
+      prerelease="${{ inputs.prerelease }}"
+      buildmeta="${{ inputs.buildmeta }}"
+      tag="${{ steps.product-version.outputs.version }}"
 
-      if [[ -n ${{ inputs.prerelease }} ]]; then
-        tag=$tag-${{ inputs.prerelease }}.${{ steps.get-revcount.outputs.revcount }}
+      if [[ -n ${prerelease} ]]; then
+        tag="${tag}-${prerelease}.${{ steps.get-revcount.outputs.revcount }}"
       fi
 
-      if [[ -n ${{ inputs.buildmeta }} ]]; then
-        tag=$tag+${{ inputs.buildmeta }}
+      if [[ -n ${buildmeta} ]]; then
+        tag="${tag}+${buildmeta}"
       fi
-      echo "tag=${tag}" >> $GITHUB_OUTPUT
+      echo "tag='${tag}'" >> $GITHUB_OUTPUT
   - id: update-tag
     shell: bash
     run: |-

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -23,14 +23,18 @@ jobs:
   test-tag:
     runs-on: ubuntu-latest
     needs: build
+    strategy:
+      matrix:
+        prerelease: ['', 'nuget']
+        buildmeta: ['', 'test']
     steps:
     - uses: actions/checkout@v3.5.0
     - uses: ./.github/actions/fetch-source
     - id: create-tag
       uses: ./.github/jobactions/tag
       with:
-        prerelease: nuget
-        buildmeta: 'xx'
+        prerelease: ${{ matrix.prerelease }}
+        buildmeta: ${{ matrix.buildmeta }}
 
   test-nuget:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- refactor ('build-pr/test-tag' job): transform 'test-tag' into matrix job
- refactor ('tag' job action): use bash variables instead of action variables
