### PR TITLE
refactor: use 'git-checkout-tags' action

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -13,7 +13,7 @@ jobs:
         configuration: [Debug, Release]
         framework: [netstandard2.1, net6.0, net7.0]
     steps:
-    - uses: actions/checkout@v3.5.0
+    - uses: kagekirin/gha-utils/.github/actions/git-checkout-tags@main
     - uses: ./.github/actions/fetch-source
     - uses: ./.github/jobactions/build
       with:
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-    - uses: actions/checkout@v3.5.0
+    - uses: kagekirin/gha-utils/.github/actions/git-checkout-tags@main
     - uses: ./.github/actions/fetch-source
     - id: create-tag
       uses: ./.github/jobactions/tag
@@ -43,6 +43,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-    - uses: actions/checkout@v3.5.0
+    - uses: kagekirin/gha-utils/.github/actions/git-checkout-tags@main
     - uses: ./.github/actions/fetch-source
     - uses: ./.github/jobactions/nuget-prepare-publish

--- a/.github/workflows/build-cron.yml
+++ b/.github/workflows/build-cron.yml
@@ -13,7 +13,7 @@ jobs:
         configuration: [Debug, Release]
         framework: [netstandard2.1, net6.0, net7.0]
     steps:
-    - uses: actions/checkout@v3.5.0
+    - uses: kagekirin/gha-utils/.github/actions/git-checkout-tags@main
     - uses: ./.github/actions/fetch-source
     - uses: ./.github/jobactions/build
       with:
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-    - uses: actions/checkout@v3.5.0
+    - uses: kagekirin/gha-utils/.github/actions/git-checkout-tags@main
     - uses: ./.github/actions/fetch-source
     - uses: ./.github/jobactions/nuget-prepare-publish
 
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: tag
     steps:
-    - uses: actions/checkout@v3.5.0
+    - uses: kagekirin/gha-utils/.github/actions/git-checkout-tags@main
     - uses: ./.github/actions/fetch-source
     - id: create-tag
       uses: ./.github/jobactions/tag

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -13,7 +13,7 @@ jobs:
         configuration: [Debug, Release]
         framework: [netstandard2.1, net6.0, net7.0]
     steps:
-    - uses: actions/checkout@v3.5.0
+    - uses: kagekirin/gha-utils/.github/actions/git-checkout-tags@main
     - uses: ./.github/actions/fetch-source
     - uses: ./.github/jobactions/build
       with:
@@ -28,7 +28,7 @@ jobs:
         prerelease: ['', 'nuget']
         buildmeta: ['', 'test']
     steps:
-    - uses: actions/checkout@v3.5.0
+    - uses: kagekirin/gha-utils/.github/actions/git-checkout-tags@main
     - uses: ./.github/actions/fetch-source
     - id: create-tag
       uses: ./.github/jobactions/tag
@@ -40,6 +40,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-    - uses: actions/checkout@v3.5.0
+    - uses: kagekirin/gha-utils/.github/actions/git-checkout-tags@main
     - uses: ./.github/actions/fetch-source
     - uses: ./.github/jobactions/nuget-prepare-publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
         configuration: [Debug, Release]
         framework: [netstandard2.1, net6.0, net7.0]
     steps:
-    - uses: actions/checkout@v3.5.0
+    - uses: kagekirin/gha-utils/.github/actions/git-checkout-tags@main
     - uses: ./.github/actions/fetch-source
     - uses: ./.github/jobactions/build
       with:
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-    - uses: actions/checkout@v3.5.0
+    - uses: kagekirin/gha-utils/.github/actions/git-checkout-tags@main
     - uses: ./.github/actions/fetch-source
     - uses: ./.github/jobactions/nuget-prepare-publish
     - uses: kagekirin/gha-dotnet/.github/actions/nuget-publish@main


### PR DESCRIPTION
- refactor ('build-pr' workflow): use 'git-checkout-tags' instead of 'actions/checkout'
- refactor ('build-ci' workflow): use 'git-checkout-tags' instead of 'actions/checkout'
- refactor ('build-cron' workflow): use 'git-checkout-tags' instead of 'actions/checkout'
- refactor ('publish' workflow): use 'git-checkout-tags' instead of 'actions/checkout'
