### PR TITLE
refactor: pass ssh-key 'secrets.DEPLOY_KEY' to 'git-checkout-tags' when pushing intended

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -25,6 +25,8 @@ jobs:
     needs: build
     steps:
     - uses: kagekirin/gha-utils/.github/actions/git-checkout-tags@main
+      with:
+        ssh-key: "${{secrets.DEPLOY_KEY}}"
     - uses: ./.github/actions/fetch-source
     - id: create-tag
       uses: ./.github/jobactions/tag
@@ -32,7 +34,7 @@ jobs:
         prerelease: nuget
     - uses: kagekirin/gha-utils/.github/actions/git-push-tag@main
       with:
-        repositoryUrl: https://${{github.token}}@github.com/KageKirin/Unity.Mathematics.NuGet
+        repositoryUrl: origin
         branch: main
 
   test-nuget:

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -34,7 +34,7 @@ jobs:
         prerelease: nuget
     - uses: kagekirin/gha-utils/.github/actions/git-push-tag@main
       with:
-        repositoryUrl: origin
+        remote: origin
         branch: main
 
   test-nuget:

--- a/.github/workflows/build-cron.yml
+++ b/.github/workflows/build-cron.yml
@@ -42,5 +42,5 @@ jobs:
         prerelease: '1'
     - uses: kagekirin/gha-utils/.github/actions/git-push-tag@main
       with:
-        repositoryUrl: origin
+        remote: origin
         branch: main

--- a/.github/workflows/build-cron.yml
+++ b/.github/workflows/build-cron.yml
@@ -33,6 +33,8 @@ jobs:
     needs: tag
     steps:
     - uses: kagekirin/gha-utils/.github/actions/git-checkout-tags@main
+      with:
+        ssh-key: "${{secrets.DEPLOY_KEY}}"
     - uses: ./.github/actions/fetch-source
     - id: create-tag
       uses: ./.github/jobactions/tag
@@ -40,5 +42,5 @@ jobs:
         prerelease: '1'
     - uses: kagekirin/gha-utils/.github/actions/git-push-tag@main
       with:
-        repositoryUrl: https://${{github.token}}@github.com/KageKirin/Unity.Mathematics.NuGet
+        repositoryUrl: origin
         branch: main


### PR DESCRIPTION
- refactor ('build-ci' workflow): pass ssh-key 'secrets.DEPLOY_KEY' to 'git-checkout-tags
- refactor ('build-cron' workflow): pass ssh-key 'secrets.DEPLOY_KEY' to 'git-checkout-tags
- refactor ('build-ci' workflow): adapt to renamed inputs.remote
- refactor ('build-cron' workflow): adapt to renamed inputs.remote
