### PR TITLE
refactor: provide inputs to 'nuget-prepare-publish' action

### DIFF
--- a/.github/jobactions/nuget-prepare-publish/action.yml
+++ b/.github/jobactions/nuget-prepare-publish/action.yml
@@ -1,14 +1,25 @@
 name: jobactions/nuget-prepare-publish
+inputs:
+  name:
+    required: true
+  registry:
+    required: false
+    default: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
+  username:
+    required: false
+    default: ${{ github.repository_owner }}
+  token:
+    required: true
 runs:
   using: composite
   steps:
   - uses: kagekirin/gha-utils/.github/actions/install-prerequisites@main
   - uses: kagekirin/gha-dotnet/.github/actions/nuget-add-registry@main
     with:
-      name: github-nuget
-      registry: https://nuget.pkg.github.com/kagekirin/unity.mathematics.nuget/index.json
-      username: kagekirin
-      token: ${{ github.token }}
+      name: ${{ inputs.name }}
+      registry: ${{ inputs.registry }}
+      username: ${{ inputs.username }}
+      token: ${{ inputs.token }}
   - uses: ./.github/jobactions/build
     with:
       framework: netstandard2.1

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -44,3 +44,6 @@ jobs:
     - uses: kagekirin/gha-utils/.github/actions/git-checkout-tags@main
     - uses: ./.github/actions/fetch-source
     - uses: ./.github/jobactions/nuget-prepare-publish
+      with:
+        name: github-nuget
+        token: ${{ secrets.GH_NUGET_TOKEN }}

--- a/.github/workflows/build-cron.yml
+++ b/.github/workflows/build-cron.yml
@@ -27,6 +27,9 @@ jobs:
     - uses: kagekirin/gha-utils/.github/actions/git-checkout-tags@main
     - uses: ./.github/actions/fetch-source
     - uses: ./.github/jobactions/nuget-prepare-publish
+      with:
+        name: github-nuget
+        token: ${{ secrets.GH_NUGET_TOKEN }}
 
   tag:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -43,3 +43,6 @@ jobs:
     - uses: kagekirin/gha-utils/.github/actions/git-checkout-tags@main
     - uses: ./.github/actions/fetch-source
     - uses: ./.github/jobactions/nuget-prepare-publish
+      with:
+        name: github-nuget
+        token: ${{ secrets.GH_NUGET_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,4 +33,4 @@ jobs:
     - uses: kagekirin/gha-dotnet/.github/actions/nuget-publish@main
       with:
         registry: github-nuget
-        token: ${{ github.token }}
+        token: ${{ secrets.GH_NUGET_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,9 @@ jobs:
     - uses: kagekirin/gha-utils/.github/actions/git-checkout-tags@main
     - uses: ./.github/actions/fetch-source
     - uses: ./.github/jobactions/nuget-prepare-publish
+      with:
+        name: github-nuget
+        token: ${{ secrets.GH_NUGET_TOKEN }}
     - uses: kagekirin/gha-dotnet/.github/actions/nuget-publish@main
       with:
         registry: github-nuget


### PR DESCRIPTION
- refactor ('nuget-prepare-publish' job action): add inputs to forward to underlying 'nuget-add-registry' action
- refactor ('build-pr/test-nuget' job): provide inputs to 'nuget-prepare-publish' action
- refactor ('build-ci/test-nuget' job): provide inputs to 'nuget-prepare-publish' action
- refactor ('build-cron/test-nuget' job): provide inputs to 'nuget-prepare-publish' action
- refactor ('publish/nuget' job): provide inputs to 'nuget-prepare-publish' action
- refactor ('publish/nuget' job): provide correct token to 'nuget-publish' action
