### PR TITLE
refactor ('build-ci' workflow): only tag on merged pull request

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'main'
+    types: [closed]
 
 jobs:
   build:

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -22,6 +22,7 @@ jobs:
         framework: ${{ matrix.framework }}
 
   tag:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     needs: build
     steps:


### PR DESCRIPTION
- refactor ('build-ci' workflow): restrict to only run on closed pull request
- refactor ('build-ci' workflow): tag only on merged pull request
